### PR TITLE
Improves flexibility of Date and Time DialogFragmentDelegates

### DIFF
--- a/DateTimePickerLibrary/src/main/java/io/doist/datetimepicker/date/TextViewWithCircularIndicator.java
+++ b/DateTimePickerLibrary/src/main/java/io/doist/datetimepicker/date/TextViewWithCircularIndicator.java
@@ -23,12 +23,12 @@ import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Typeface;
 import android.support.annotation.NonNull;
+import android.support.v7.widget.AppCompatTextView;
 import android.util.AttributeSet;
-import android.widget.TextView;
 
 import io.doist.datetimepicker.R;
 
-public class TextViewWithCircularIndicator extends TextView {
+public class TextViewWithCircularIndicator extends AppCompatTextView {
 
     private static final int SELECTED_CIRCLE_ALPHA = 60;
 

--- a/DateTimePickerLibrary/src/main/java/io/doist/datetimepicker/fragment/DatePickerDialogFragment.java
+++ b/DateTimePickerLibrary/src/main/java/io/doist/datetimepicker/fragment/DatePickerDialogFragment.java
@@ -30,7 +30,7 @@ import io.doist.datetimepicker.date.OnDateSetListener;
 public class DatePickerDialogFragment extends DialogFragment {
     public static final String TAG = DatePickerDialogFragment.class.getName();
 
-    private DatePickerDialogFragmentDelegate mDelegate;
+    protected DatePickerDialogFragmentDelegate mDelegate;
 
     public DatePickerDialogFragment() {
         mDelegate = onCreateDatePickerDialogFragmentDelegate();

--- a/DateTimePickerLibrary/src/main/java/io/doist/datetimepicker/fragment/DatePickerDialogFragmentCompat.java
+++ b/DateTimePickerLibrary/src/main/java/io/doist/datetimepicker/fragment/DatePickerDialogFragmentCompat.java
@@ -30,7 +30,7 @@ import io.doist.datetimepicker.date.OnDateSetListener;
 public class DatePickerDialogFragmentCompat extends DialogFragment {
     public static final String TAG = DatePickerDialogFragmentCompat.class.getName();
 
-    private DatePickerDialogFragmentDelegate mDelegate;
+    protected DatePickerDialogFragmentDelegate mDelegate;
 
     public DatePickerDialogFragmentCompat() {
         mDelegate = onCreateDatePickerDialogFragmentDelegate();

--- a/DateTimePickerLibrary/src/main/java/io/doist/datetimepicker/fragment/DatePickerDialogFragmentDelegate.java
+++ b/DateTimePickerLibrary/src/main/java/io/doist/datetimepicker/fragment/DatePickerDialogFragmentDelegate.java
@@ -80,15 +80,19 @@ public class DatePickerDialogFragmentDelegate extends PickerDialogFragmentDelega
         mDatePicker.init(year, monthOfYear, dayOfMonth, this);
     }
 
-    public void setOnDateSetListener(OnDateSetListener listener) {
-        mOnDateSetListener = listener;
+    public void updateDate(int year, int monthOfYear, int dayOfMonth) {
+        mDatePicker.updateDate(year, monthOfYear, dayOfMonth);
     }
 
     public DatePicker getDatePicker() {
         return mDatePicker;
     }
 
-    public void updateDate(int year, int monthOfYear, int dayOfMonth) {
-        mDatePicker.updateDate(year, monthOfYear, dayOfMonth);
+    public void setOnDateSetListener(OnDateSetListener listener) {
+        mOnDateSetListener = listener;
+    }
+
+    public OnDateSetListener getOnDateSetListener() {
+        return mOnDateSetListener;
     }
 }

--- a/DateTimePickerLibrary/src/main/java/io/doist/datetimepicker/fragment/DatePickerDialogFragmentDelegate.java
+++ b/DateTimePickerLibrary/src/main/java/io/doist/datetimepicker/fragment/DatePickerDialogFragmentDelegate.java
@@ -17,9 +17,9 @@ public class DatePickerDialogFragmentDelegate extends PickerDialogFragmentDelega
     private static final String KEY_MONTH_OF_YEAR = "month";
     private static final String KEY_DAY_OF_MONTH = "day";
 
-    private DatePicker mDatePicker;
+    protected DatePicker mDatePicker;
 
-    private OnDateSetListener mOnDateSetListener;
+    protected OnDateSetListener mOnDateSetListener;
 
     public static Bundle createArguments(int year, int monthOfYear, int dayOfMonth) {
         Bundle arguments = new Bundle();

--- a/DateTimePickerLibrary/src/main/java/io/doist/datetimepicker/fragment/TimePickerDialogFragment.java
+++ b/DateTimePickerLibrary/src/main/java/io/doist/datetimepicker/fragment/TimePickerDialogFragment.java
@@ -34,7 +34,7 @@ import io.doist.datetimepicker.time.TimePicker;
 public class TimePickerDialogFragment extends DialogFragment {
     public static final String TAG = TimePickerDialogFragment.class.getName();
 
-    private TimePickerDialogFragmentDelegate mDelegate;
+    protected TimePickerDialogFragmentDelegate mDelegate;
 
     public TimePickerDialogFragment() {
         mDelegate = onCreateTimePickerDialogFragmentDelegate();

--- a/DateTimePickerLibrary/src/main/java/io/doist/datetimepicker/fragment/TimePickerDialogFragmentCompat.java
+++ b/DateTimePickerLibrary/src/main/java/io/doist/datetimepicker/fragment/TimePickerDialogFragmentCompat.java
@@ -34,7 +34,7 @@ import io.doist.datetimepicker.time.TimePicker;
 public class TimePickerDialogFragmentCompat extends DialogFragment {
     public static final String TAG = TimePickerDialogFragmentCompat.class.getName();
 
-    private TimePickerDialogFragmentDelegate mDelegate;
+    protected TimePickerDialogFragmentDelegate mDelegate;
 
     public TimePickerDialogFragmentCompat() {
         mDelegate = onCreateTimePickerDialogFragmentDelegate();

--- a/DateTimePickerLibrary/src/main/java/io/doist/datetimepicker/fragment/TimePickerDialogFragmentDelegate.java
+++ b/DateTimePickerLibrary/src/main/java/io/doist/datetimepicker/fragment/TimePickerDialogFragmentDelegate.java
@@ -77,21 +77,25 @@ public class TimePickerDialogFragmentDelegate extends PickerDialogFragmentDelega
                     });
     }
 
-    public void setOnTimeSetListener(OnTimeSetListener listener) {
-        mOnTimeSetListener = listener;
-    }
-
     @Override
     public void onTimeChanged(TimePicker view, int hourOfDay, int minute) {
         // Do nothing.
+    }
+
+    public void updateTime(int hourOfDay, int minuteOfHour) {
+        mTimePicker.setCurrentHour(hourOfDay);
+        mTimePicker.setCurrentMinute(minuteOfHour);
     }
 
     public TimePicker getTimePicker() {
         return mTimePicker;
     }
 
-    public void updateTime(int hourOfDay, int minuteOfHour) {
-        mTimePicker.setCurrentHour(hourOfDay);
-        mTimePicker.setCurrentMinute(minuteOfHour);
+    public void setOnTimeSetListener(OnTimeSetListener listener) {
+        mOnTimeSetListener = listener;
+    }
+
+    public OnTimeSetListener getOnTimeSetListener() {
+        return mOnTimeSetListener;
     }
 }

--- a/DateTimePickerLibrary/src/main/java/io/doist/datetimepicker/fragment/TimePickerDialogFragmentDelegate.java
+++ b/DateTimePickerLibrary/src/main/java/io/doist/datetimepicker/fragment/TimePickerDialogFragmentDelegate.java
@@ -17,9 +17,9 @@ public class TimePickerDialogFragmentDelegate extends PickerDialogFragmentDelega
     private static final String KEY_MINUTE = "minute";
     private static final String KEY_IS_24_HOUR = "is24Hour";
 
-    private TimePicker mTimePicker;
+    protected TimePicker mTimePicker;
 
-    private OnTimeSetListener mOnTimeSetListener;
+    protected OnTimeSetListener mOnTimeSetListener;
 
     public static Bundle createArguments(int hourOfDay, int minute, boolean is24Hour) {
         Bundle arguments = new Bundle();

--- a/DateTimePickerLibrary/src/main/java/io/doist/datetimepicker/time/RadialTimePickerView.java
+++ b/DateTimePickerLibrary/src/main/java/io/doist/datetimepicker/time/RadialTimePickerView.java
@@ -339,43 +339,9 @@ public class RadialTimePickerView extends View implements View.OnTouchListener {
         mPaintCenter.setAntiAlias(true);
         mPaintCenter.setTextAlign(Paint.Align.CENTER);
 
-        mPaintSelector[HOURS][SELECTOR_CIRCLE] = new Paint();
-        mPaintSelector[HOURS][SELECTOR_CIRCLE].setAntiAlias(true);
-        mColorSelector[HOURS][SELECTOR_CIRCLE] = a.getColor(
+        setSelectorColor(a.getColor(
                 R.styleable.TimePicker_numbersSelectorColor,
-                ContextCompat.getColor(context, R.color.timepicker_default_selector_color_material));
-
-        mPaintSelector[HOURS][SELECTOR_DOT] = new Paint();
-        mPaintSelector[HOURS][SELECTOR_DOT].setAntiAlias(true);
-        mColorSelector[HOURS][SELECTOR_DOT] = a.getColor(
-                R.styleable.TimePicker_numbersSelectorColor,
-                ContextCompat.getColor(context, R.color.timepicker_default_selector_color_material));
-
-        mPaintSelector[HOURS][SELECTOR_LINE] = new Paint();
-        mPaintSelector[HOURS][SELECTOR_LINE].setAntiAlias(true);
-        mPaintSelector[HOURS][SELECTOR_LINE].setStrokeWidth(2);
-        mColorSelector[HOURS][SELECTOR_LINE] = a.getColor(
-                R.styleable.TimePicker_numbersSelectorColor,
-                ContextCompat.getColor(context, R.color.timepicker_default_selector_color_material));
-
-        mPaintSelector[MINUTES][SELECTOR_CIRCLE] = new Paint();
-        mPaintSelector[MINUTES][SELECTOR_CIRCLE].setAntiAlias(true);
-        mColorSelector[MINUTES][SELECTOR_CIRCLE] = a.getColor(
-                R.styleable.TimePicker_numbersSelectorColor,
-                ContextCompat.getColor(context, R.color.timepicker_default_selector_color_material));
-
-        mPaintSelector[MINUTES][SELECTOR_DOT] = new Paint();
-        mPaintSelector[MINUTES][SELECTOR_DOT].setAntiAlias(true);
-        mColorSelector[MINUTES][SELECTOR_DOT] = a.getColor(
-                R.styleable.TimePicker_numbersSelectorColor,
-                ContextCompat.getColor(context, R.color.timepicker_default_selector_color_material));
-
-        mPaintSelector[MINUTES][SELECTOR_LINE] = new Paint();
-        mPaintSelector[MINUTES][SELECTOR_LINE].setAntiAlias(true);
-        mPaintSelector[MINUTES][SELECTOR_LINE].setStrokeWidth(2);
-        mColorSelector[MINUTES][SELECTOR_LINE] = a.getColor(
-                R.styleable.TimePicker_numbersSelectorColor,
-                ContextCompat.getColor(context, R.color.timepicker_default_selector_color_material));
+                ContextCompat.getColor(context, R.color.timepicker_default_selector_color_material)));
 
         mPaintBackground.setColor(a.getColor(R.styleable.TimePicker_numbersBackgroundColor,
                 res.getColor(R.color.timepicker_default_numbers_background_color_material)));
@@ -429,6 +395,34 @@ public class RadialTimePickerView extends View implements View.OnTouchListener {
         setCurrentMinuteInternal(currentMinute, false);
 
         setHapticFeedbackEnabled(true);
+    }
+
+    public void setSelectorColor(int color) {
+        mPaintSelector[HOURS][SELECTOR_CIRCLE] = new Paint();
+        mPaintSelector[HOURS][SELECTOR_CIRCLE].setAntiAlias(true);
+        mColorSelector[HOURS][SELECTOR_CIRCLE] = color;
+
+        mPaintSelector[HOURS][SELECTOR_DOT] = new Paint();
+        mPaintSelector[HOURS][SELECTOR_DOT].setAntiAlias(true);
+        mColorSelector[HOURS][SELECTOR_DOT] = color;
+
+        mPaintSelector[HOURS][SELECTOR_LINE] = new Paint();
+        mPaintSelector[HOURS][SELECTOR_LINE].setAntiAlias(true);
+        mPaintSelector[HOURS][SELECTOR_LINE].setStrokeWidth(2);
+        mColorSelector[HOURS][SELECTOR_LINE] = color;
+
+        mPaintSelector[MINUTES][SELECTOR_CIRCLE] = new Paint();
+        mPaintSelector[MINUTES][SELECTOR_CIRCLE].setAntiAlias(true);
+        mColorSelector[MINUTES][SELECTOR_CIRCLE] = color;
+
+        mPaintSelector[MINUTES][SELECTOR_DOT] = new Paint();
+        mPaintSelector[MINUTES][SELECTOR_DOT].setAntiAlias(true);
+        mColorSelector[MINUTES][SELECTOR_DOT] = color;
+
+        mPaintSelector[MINUTES][SELECTOR_LINE] = new Paint();
+        mPaintSelector[MINUTES][SELECTOR_LINE].setAntiAlias(true);
+        mPaintSelector[MINUTES][SELECTOR_LINE].setStrokeWidth(2);
+        mColorSelector[MINUTES][SELECTOR_LINE] = color;
     }
 
     /**


### PR DESCRIPTION
The way `DatePickerDialogFragment`, `DatePickerDialogFragmentCompat`, `TimePickerDialogFragment`, and `TimePickerDialogFragmentCompat` have `onCreateDatePickerDialogFragmentDelegate` and `onCreateTimePickerDialogFragmentDelegate` defined as `protected` methods, indicates they were designed to allow subclasses to override those methods to alter the dialog.

However, the delegates themselves (`DatePickerDialogFragmentDelegate` and `TimePickerDialogFragmentDelegate`) have their pickers (`DatePicker` and `TimePicker`), as well as their listeners (`OnDateSetListener` and `OnTimeSetListener`), defined as `private`.

This choice was probably an oversight on my part, as I think I never actually needed to override them. However, that choice makes it (while still possible) somewhat troublesome to override the delegates to alter the dialog builder.

I think that changing their visibility to `protected` would make sense, as it would avoid the need to override `setOnTimeSetListener`, as well as the need to find the `DatePicker` and `TimePicker` on `onCreateDialogView`.

Note: I want to add a negative button to the dialog, and that would help a lot. 😄

Edit (after `0d232a9`):
Adds methods to get `OnDateSetListener` and `OnTimeSetListener` from delegates.
Since `DialogFragment` overrides some `Dialog` listeners (like `OnCancelListener` or `OnDismissListener`) it might be useful to access `OnDateSetListener` or `OnTimeSetListener` directly from the `DialogFragment`.

Edit (after `9a27bf5`):
Changes `mDelegate` visibility on all `DialogFragments`, to avoid the need to override `onCreateDatePickerDialogFragmentDelegate` and `onCreateTimePickerDialogFragmentDelegate`.

Summary:
This PR is not so much about giving access, but more about making the access easier, as every component could already be accessed before, but it was just harder.