### PR TITLE
Remove build tools version

### DIFF
--- a/DateTimePickerLibrary/build.gradle
+++ b/DateTimePickerLibrary/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 31
-    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 16

--- a/DateTimePickerSamples/build.gradle
+++ b/DateTimePickerSamples/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 31
-    buildToolsVersion "28.0.3"
 
     defaultConfig {
         applicationId "io.doist.datetimepicker.sample"


### PR DESCRIPTION
The Android Gradle Plugin has a default version of the build tools anyway, so this was now a warning. 