### PR TITLE
 Move package name to namespace in Gradle for AGP 8

### DIFF
--- a/DateTimePickerLibrary/build.gradle
+++ b/DateTimePickerLibrary/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace "io.doist.datetimepicker"
     compileSdkVersion 31
 
     defaultConfig {

--- a/DateTimePickerLibrary/src/main/AndroidManifest.xml
+++ b/DateTimePickerLibrary/src/main/AndroidManifest.xml
@@ -13,8 +13,7 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.doist.datetimepicker">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.VIBRATE" />
 


### PR DESCRIPTION
Ref: [developer.android.com/studio/releases/gradle-plugin](https://developer.android.com/studio/releases/gradle-plugin)


Umm, shouldn't we move away from this library?