### PR TITLE
Use non-transitive R class in preparation for AGP 8

### DIFF
--- a/DateTimePickerLibrary/src/main/java/io/doist/datetimepicker/date/SimpleMonthAdapter.java
+++ b/DateTimePickerLibrary/src/main/java/io/doist/datetimepicker/date/SimpleMonthAdapter.java
@@ -97,7 +97,8 @@ class SimpleMonthAdapter extends BaseAdapter {
     void setCalendarTextAppearance(int resId) {
         final TypedArray a = mContext.obtainStyledAttributes(resId, R.styleable.TextAppearance);
 
-        final ColorStateList textColor = a.getColorStateList(R.styleable.TextAppearance_android_textColor);
+        final ColorStateList textColor = a.getColorStateList(
+                androidx.appcompat.R.styleable.TextAppearance_android_textColor);
         if (textColor != null) {
             mCalendarTextColors = textColor;
         }

--- a/DateTimePickerLibrary/src/main/java/io/doist/datetimepicker/fragment/PickerDialogFragmentDelegate.java
+++ b/DateTimePickerLibrary/src/main/java/io/doist/datetimepicker/fragment/PickerDialogFragmentDelegate.java
@@ -31,7 +31,9 @@ abstract class PickerDialogFragmentDelegate {
             if (outValue.resourceId >= 0x01000000) {
                 return outValue.resourceId;
             } else {
-                context.getTheme().resolveAttribute(R.attr.alertDialogTheme, outValue, true);
+                context.getTheme()
+                       .resolveAttribute(androidx.appcompat.R.attr.alertDialogTheme, outValue,
+                                         true);
                 return outValue.resourceId;
             }
         }


### PR DESCRIPTION
AGP 8 requires us to use non-transitive R classes to improve build times.

https://developer.android.com/build/optimize-your-build#use-non-transitive-r-classes